### PR TITLE
open .osm with utf-8 encoding enabled

### DIFF
--- a/PythonAPI/util/config.py
+++ b/PythonAPI/util/config.py
@@ -206,7 +206,7 @@ def main():
         world = client.reload_world()
     elif args.xodr_path is not None:
         if os.path.exists(args.xodr_path):
-            with open(args.xodr_path) as od_file:
+            with open(args.xodr_path, encoding='utf-8') as od_file:
                 try:
                     data = od_file.read()
                 except OSError:


### PR DESCRIPTION
As the .osm files are utf-8 encoded, it was raising errors while running the config.py script. Added the parameter `encoding='utf-8'` to solve it.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
As the .osm files are utf-8 encoded, it was raising errors while running the config.py script. Added the parameter `encoding='utf-8'` to solve it.
Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
windown 10
  * **Python version(s):** ...
python3.6 and 3.8
  * **Unreal Engine version(s):** ...
UE 4.24.3
#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
